### PR TITLE
Some typo, capitalization, and text fixes

### DIFF
--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -1,47 +1,48 @@
 .row
-  %h2.center The community's ruby implementation
+  %h2.center The community's Ruby implementation
   %div
     %p.center
       %span
-        Ruby imiplemented in 100% ruby, for everyone.
+        Ruby implemented in 100% Ruby, for everyone.
 .row
   .tripple
     %h2.center What
     %p
       RubyX
       %b compiles
-      ruby code to binary.
+      Ruby code to binary.
       %br
       In
       %b 100%
-      pure ruby.
+      pure Ruby.
     %p
       The goal here is to prove that dynamic languages do not have to be slow.
       %br
       Only interpretation is slow, but when
-      ruby is
-      %b compiled to binary
-      ,it can be really fast.
+      Ruby is
+      =succeed "," do
+        %b compiled to binary
+      it can be really fast.
     %p
       How fast (X times), will eventually depend on the community.
-      The RubyX approach works, but to create an mri compatible ruby will
-      take many more man-years than i have.
+      The RubyX approach works, but to create an MRI compatible Ruby will
+      take many more man-years than I have.
     %p
       RubyX is here to
       =succeed "," do
         =link_to "empower you" , "/project/motivation.html"
-      to make your ruby shine as much as you like.
+      to make your Ruby shine as much as you like.
     %p
-      Since rubyX is written in ruby, anyone can easily join, and
+      Since RubyX is written in Ruby, anyone can easily join, and
       the project is very open to newcomers. In time the idea is to implement
       a democratic version of open source, as an alternative the current
       "benevolent dictator" model.
     %p
       Contrary to what many newcomers think, ruby-x is also technically easy to join.
-      In the end it is just ruby, and only a very small percent of code is low level.
+      In the end it is just Ruby, and only a very small percent of code is low level.
       We have a list
       =ext_link "of issues" , "https://github.com/ruby-x/rubyx/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+newbie%22"
-      in github for beginners.
+      in GitHub for beginners.
   .tripple
     %h2.center Status
     %p
@@ -49,7 +50,7 @@
       =link_to "architecture", "/rubyx/layers.html"
       has been refined over several years.
     %p
-      A substantial part of the ruby language has been implemented:
+      A substantial part of the Ruby language has been implemented:
     %ul
       %li
         Object oriented
@@ -78,12 +79,12 @@
         =ext_link "Risc machine abstraction" , "https://github.com/ruby-x/rubyx/tree/master/lib/risc"
         (includes extensible instruction)
       %li
-        A minimal Arm and Elf implementation to create
+        A minimal ARM and ELF implementation to create
         = succeed "." do
           %b working binaries
     %h2.center Upcoming work
     %p
-      But there is still a lot of work, here are just the next few topics
+      But there is still a lot of work, here are some of the next few topics
       %ul
         %li Dynamic Memory management
         %li Benchmarks for calling and integer
@@ -99,8 +100,9 @@
       The presentation for
       = ext_link "GrillRb" , "/slides/grillrb"
       is more detailed than the previous unconf Hamburg one.
-      But a 20min video was made in hamburg and can be found
-      = ext_link "on youtube" , "https://youtu.be/ojW-q_wiSn8"
+      But a 20 minute video was made in Hamburg and can be found
+      =succeed "." do
+        = ext_link "on youtube" , "https://youtu.be/ojW-q_wiSn8"
     %p
       To get to know the system, there is also an interpreter and a basic
       =succeed "." do
@@ -115,7 +117,7 @@
         =ext_link "mail to the group" , "https://groups.google.com/forum/#!forum/ruby-x"
     %h2.center News
     %p
-      Last but not least, i try to get recent developments down on paper when they are
+      Last but not least, I try to get recent developments down on paper when they are
       still fresh.
     %p=post_link(Post.posts.values[0])
     %p=post_link(Post.posts.values[1])


### PR DESCRIPTION
Just wanted to fix the typo for `implemented` in the heading, but ended up changing some comas and capitalizations in the text.

@rubydesign Thanks for RubyX, hoping to explore it more in the coming weeks.